### PR TITLE
Added memfd feature to support copying without a temp file on disk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 **/*.rs.bk
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /target
 **/*.rs.bk
-.vscode/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,6 +404,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "memfd"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
+dependencies = [
+ "rustix",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,6 +1076,7 @@ version = "0.9.2"
 dependencies = [
  "libc",
  "log",
+ "memfd",
  "os_pipe",
  "proptest",
  "proptest-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ wayland-backend = "0.3.8"
 wayland-client = "0.31.8"
 wayland-protocols = { version = "0.32.6", features = ["client", "staging"] }
 wayland-protocols-wlr = { version = "0.3.6", features = ["client"] }
+memfd = { version = "0.6", optional = true }
 
 [dev-dependencies]
 wayland-server = "0.31.7"
@@ -53,3 +54,6 @@ proptest-derive = "0.5.1"
 native_lib = ["wayland-backend/client_system", "wayland-backend/server_system"]
 
 dlopen = ["native_lib", "wayland-backend/dlopen", "wayland-backend/dlopen"]
+
+# Use an in-memory temporary file for copying
+memfd = ["dep:memfd"]

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -179,10 +179,6 @@ pub enum SourceCreationError {
     #[cfg(feature = "memfd")]
     #[error("Couldn't seal the memfd file")]
     MemFdFileSeal(#[source] memfd::Error),
-
-    #[cfg(feature = "memfd")]
-    #[error("File is not compatible with memfd")]
-    MemFdFileNotCompatible,
 }
 
 /// Errors that can occur for copying and clearing the clipboard.


### PR DESCRIPTION
The `memfd` feature allows the clipboard to work without creating a temporary file on disk, making the create more suitable for security-sensitive applications e.g. copying passwords.