### PR TITLE
Rebuild in-memory copy backend and fix regressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,15 +404,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "memfd"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
-dependencies = [
- "rustix",
-]
-
-[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,7 +1067,6 @@ version = "0.9.2"
 dependencies = [
  "libc",
  "log",
- "memfd",
  "os_pipe",
  "proptest",
  "proptest-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ wayland-backend = "0.3.8"
 wayland-client = "0.31.8"
 wayland-protocols = { version = "0.32.6", features = ["client", "staging"] }
 wayland-protocols-wlr = { version = "0.3.6", features = ["client"] }
-memfd = { version = "0.6", optional = true }
 
 [dev-dependencies]
 wayland-server = "0.31.7"
@@ -55,5 +54,6 @@ native_lib = ["wayland-backend/client_system", "wayland-backend/server_system"]
 
 dlopen = ["native_lib", "wayland-backend/dlopen", "wayland-backend/dlopen"]
 
-# Use an in-memory temporary file for copying
-memfd = ["dep:memfd"]
+# Use in-memory storage for serving clipboard contents instead of a temporary
+# file on disk.
+in-memory = []

--- a/wl-clipboard-rs-tools/Cargo.toml
+++ b/wl-clipboard-rs-tools/Cargo.toml
@@ -35,3 +35,5 @@ native_lib = [
 dlopen = [
     "wl-clipboard-rs/dlopen",
 ]
+
+memfd = ["wl-clipboard-rs/memfd"]

--- a/wl-clipboard-rs-tools/Cargo.toml
+++ b/wl-clipboard-rs-tools/Cargo.toml
@@ -36,4 +36,4 @@ dlopen = [
     "wl-clipboard-rs/dlopen",
 ]
 
-memfd = ["wl-clipboard-rs/memfd"]
+in-memory = ["wl-clipboard-rs/in-memory"]


### PR DESCRIPTION
This PR does three things:
- Fix a regression from #1 where I forgot an offset reset operation after each send event copy.
    - This went unnoticed before because the _first_ copy worked fine. However this surfaced as a problem when testing on KDE where there's a platform clipboard manager that always makes the first request to data sources to copy them. After that `CTRL+V` only returned an empty string.
- Fixed another regression where the large amount of refactoring messed up when MIME types got detected. This went unnoticed because `arboard` always passes an explicit MIME in instead of relying on magic byte detection.
    - Previously the code was trying to detect the MIME of a fresh file, which would never return anything.

Finally, it replaces the `memfd` in-memory storage backend for copying with a similar implementation based on `Arc` instead. It turns out we weren't really using `memfd`'s full capabilities:
- Sealing was irrelevant because  we never transmitted the FD out of our process.
- Storing it as an FD always was unneeded and added more error cases since we always _copy out_ into the send event's file descriptor. We don't need another FD to do that, just anything that implements `std::io::Read.`

Using `Arc` instead has some benefits too:
- Better security: We no longer create anonymous files in `/proc/$pid/fd/` that can be read by any same-user process. 
    - Until clipboard contents are requested they are now protected by `/proc/$pid/mem`'s stricter rules instead.
- Performance: Copying bytes inside Rust during setup without any `libc` I/O is always going to be far faster as it can use more closely optimized copy routines.
- Less chance of inducing `fd` exhaustion in a resource-intensive app since we no longer create `O(N)` FDs when copying to the clipboard for each MIME type.
- Ease of maintenance: By using an `Arc`, we make it clear in the type system that once a data source is created, its read-only until destruction. Additionally, there's now less places we need to worry about seeking offset issues.
    - Everything has also been gated such that, if the tempdir storage implementation is dropped, its a trivial refactor that will still result in clean code.

This was tested extensively on KDE Plasma. The `wl-copy` tool has the correct behavior again serving requests and `cargo test` still passes.